### PR TITLE
Generate trajectories using various time intervals too as in paper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /root/nav2_ws
 RUN cd src && \
     git clone https://github.com/CihatAltiparmak/frenet_ilqr_controller.git
 
-RUN wget https://gist.githubusercontent.com/CihatAltiparmak/7171fbb514287501ce91e9c45c69dab2/raw/e8d2f18c237cf2a5054f64dd7c1be774939bd31c/nav2_param_frenet_ilqr_controller_demo.yaml -O src/navigation2/nav2_bringup/params/nav2_param_frenet_ilqr_controller_demo.yaml
+RUN wget https://gist.githubusercontent.com/CihatAltiparmak/7171fbb514287501ce91e9c45c69dab2/raw/253715db39b1517f0eb1d3df7e5b944e671835e0/nav2_param_frenet_ilqr_controller_demo.yaml -O src/navigation2/nav2_bringup/params/nav2_param_frenet_ilqr_controller_demo.yaml
 
 RUN . /opt/ros/rolling/setup.sh && \
     colcon build --packages-select nav2_bringup nav2_frenet_ilqr_controller frenet_trajectory_planner ilqr_trajectory_tracker --cmake-args -DCMAKE_BUILD_TYPE=Release

--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ docker run -it --gpus=all -e NVIDIA_DRIVER_CAPABILITIES=all --runtime=nvidia --r
 | step_lateral_distance      | double | Default: +0.05.  Increasing rate for producing lateral distance trajectories in Frenet Frame |
 | min_longitital_velocity    | double | Default:  0.0. Minimum longitutal velocity along interpolated curve. |
 | max_longitital_velocity    | double | Default: +0.5. Maximum longitutal velocity along interpolated curve. |
-| step_lateral_distance      | double | Default: +0.05.  Increasing rate for producing longtitutal velocity trajectories in Frenet Frame |
-| time_interval              | double | Default: 0.7.  time (s) required to achieve corresponding frenet state. Used by polynomial trajectory planning for both velocity planning and lateral distance planning, (e.g time (s) required to increase speed from 1.0 m/s to 2 m/s)|
+| step_longtitutal_velocity  | double | Default: +0.05.  Increasing rate for producing longtitutal velocity trajectories in Frenet Frame |
+| min_time_interval          | double | Default:  0.7 (s). Minimum time interval the trajectory is able to be planned |
+| max_time_interval          | double | Default: +0.8. (s) Maximum time interval the trajectory is able to be planned |
+| step_time_interval         | double | Default: +0.1.  Increasing rate of time_interval from min_time_interval to max_time_interval |
 | max_state_in_trajectory    | int | Default: 40.  the number of how many state the generated trajectory can have at most.  |
 
 #### Iterative Linear Quadratic Regulator
@@ -115,7 +117,9 @@ controller_server:
         min_longtitutal_velocity: 0.0
         max_longtitutal_velocity: 0.5
         step_longtitutal_velocity: 0.05
-        time_interval: 0.7
+        min_time_interval: 0.7
+        max_time_interval: 0.8
+        step_time_interval: 0.1
         max_state_in_trajectory: 40
       ilqr_trajectory_tracker:
         q_coefficients: [1.0, 1.0, 1.0, 1.0]

--- a/frenet_trajectory_planner/include/frenet_trajectory_planner/frenet_trajectory_generator.hpp
+++ b/frenet_trajectory_planner/include/frenet_trajectory_planner/frenet_trajectory_generator.hpp
@@ -41,7 +41,8 @@ public:
   FrenetTrajectory getFrenetTrajectory(
     const FrenetState & frenet_state_initial,
     const FrenetState & frenet_state_final,
-    const size_t max_state_number);
+    const size_t max_state_number,
+    const double time_interval);
 
 private:
   FrenetTrajectoryPlannerConfig frenet_planner_config_;

--- a/frenet_trajectory_planner/include/frenet_trajectory_planner/type_definitions.hpp
+++ b/frenet_trajectory_planner/include/frenet_trajectory_planner/type_definitions.hpp
@@ -45,7 +45,9 @@ typedef struct FrenetTrajectoryPlannerConfig
   double min_longtitutal_velocity;
   double max_longtitutal_velocity;
   double step_longtitutal_velocity;
-  double time_interval = 1;
+  double min_time_interval;
+  double max_time_interval;
+  double step_time_interval;
   int max_state_in_trajectory = 40;
   double dt = 0.05;  // time discretization
 } FrenetTrajectoryPlannerConfig;

--- a/frenet_trajectory_planner/src/frenet_trajectory_generator.cpp
+++ b/frenet_trajectory_planner/src/frenet_trajectory_generator.cpp
@@ -32,7 +32,8 @@ std::vector<FrenetTrajectory> FrenetTrajectoryGenerator::getAllPossibleFrenetTra
   std::vector<FrenetTrajectory> frenet_trajectories;
   for (double time_interval = frenet_planner_config_.min_time_interval;
     time_interval <= frenet_planner_config_.max_time_interval;
-    time_interval += frenet_planner_config_.step_time_interval) {
+    time_interval += frenet_planner_config_.step_time_interval)
+  {
     for (double longtitutal_velocity_final = frenet_planner_config_.min_longtitutal_velocity;
       longtitutal_velocity_final <= frenet_planner_config_.max_longtitutal_velocity;
       longtitutal_velocity_final += frenet_planner_config_.step_longtitutal_velocity)

--- a/frenet_trajectory_planner/src/frenet_trajectory_generator.cpp
+++ b/frenet_trajectory_planner/src/frenet_trajectory_generator.cpp
@@ -30,27 +30,31 @@ std::vector<FrenetTrajectory> FrenetTrajectoryGenerator::getAllPossibleFrenetTra
   const FrenetState & frenet_state_initial, size_t max_state_number)
 {
   std::vector<FrenetTrajectory> frenet_trajectories;
-  for (double longtitutal_velocity_final = frenet_planner_config_.min_longtitutal_velocity;
-    longtitutal_velocity_final <= frenet_planner_config_.max_longtitutal_velocity;
-    longtitutal_velocity_final += frenet_planner_config_.step_longtitutal_velocity)
-  {
-    for (double lateral_distance_final = frenet_planner_config_.min_lateral_distance;
-      lateral_distance_final <= frenet_planner_config_.max_lateral_distance;
-      lateral_distance_final += frenet_planner_config_.step_lateral_distance)
+  for (double time_interval = frenet_planner_config_.min_time_interval;
+    time_interval <= frenet_planner_config_.max_time_interval;
+    time_interval += frenet_planner_config_.step_time_interval) {
+    for (double longtitutal_velocity_final = frenet_planner_config_.min_longtitutal_velocity;
+      longtitutal_velocity_final <= frenet_planner_config_.max_longtitutal_velocity;
+      longtitutal_velocity_final += frenet_planner_config_.step_longtitutal_velocity)
     {
-      StateLongtitutal state_longtitutal_final;
-      state_longtitutal_final << 0, longtitutal_velocity_final, 0;
+      for (double lateral_distance_final = frenet_planner_config_.min_lateral_distance;
+        lateral_distance_final <= frenet_planner_config_.max_lateral_distance;
+        lateral_distance_final += frenet_planner_config_.step_lateral_distance)
+      {
+        StateLongtitutal state_longtitutal_final;
+        state_longtitutal_final << 0, longtitutal_velocity_final, 0;
 
-      StateLateral state_lateral_final;
-      state_lateral_final << lateral_distance_final, 0, 0;
+        StateLateral state_lateral_final;
+        state_lateral_final << lateral_distance_final, 0, 0;
 
-      FrenetState frenet_state_final;
-      frenet_state_final << state_longtitutal_final, state_lateral_final;
-      auto frenet_trajectory = getFrenetTrajectory(
-        frenet_state_initial, frenet_state_final,
-        max_state_number);
-      if (!frenet_trajectory.empty()) {
-        frenet_trajectories.push_back(frenet_trajectory);
+        FrenetState frenet_state_final;
+        frenet_state_final << state_longtitutal_final, state_lateral_final;
+        auto frenet_trajectory = getFrenetTrajectory(
+          frenet_state_initial, frenet_state_final,
+          max_state_number, time_interval);
+        if (!frenet_trajectory.empty()) {
+          frenet_trajectories.push_back(frenet_trajectory);
+        }
       }
     }
   }
@@ -60,7 +64,9 @@ std::vector<FrenetTrajectory> FrenetTrajectoryGenerator::getAllPossibleFrenetTra
 
 FrenetTrajectory FrenetTrajectoryGenerator::getFrenetTrajectory(
   const FrenetState & frenet_state_initial,
-  const FrenetState & frenet_state_final, const size_t max_state_number)
+  const FrenetState & frenet_state_final,
+  const size_t max_state_number,
+  const double time_interval)
 {
   auto longtitual_state_initial = frenet_state_initial(seq(0, 2));
   auto longtitual_state_final = frenet_state_final(seq(0, 2));
@@ -68,7 +74,7 @@ FrenetTrajectory FrenetTrajectoryGenerator::getFrenetTrajectory(
   if (!longtitutal_velocity_planner.setCoefficientsOrReturnFalse(
       longtitual_state_initial[0], longtitual_state_initial[1], longtitual_state_initial[2],
       longtitual_state_final[1], longtitual_state_final[2],
-      0, frenet_planner_config_.time_interval))
+      0, time_interval))
   {
     return {};
   }
@@ -79,7 +85,7 @@ FrenetTrajectory FrenetTrajectoryGenerator::getFrenetTrajectory(
   if (!lateral_distance_planner.setCoefficientsOrReturnFalse(
       lateral_state_initial[0], lateral_state_initial[1], lateral_state_initial[2],
       lateral_state_final[0], lateral_state_final[1], lateral_state_final[2],
-      0, frenet_planner_config_.time_interval))
+      0, time_interval))
   {
     return {};
   }
@@ -89,7 +95,7 @@ FrenetTrajectory FrenetTrajectoryGenerator::getFrenetTrajectory(
   // assert dt is smaller than time_interval
   double maximum_time_interval = std::min(
     frenet_planner_config_.dt * max_state_number,
-    frenet_planner_config_.time_interval);
+    time_interval);
   for (double t = 0; t <= maximum_time_interval; t += frenet_planner_config_.dt) {
     StateLongtitutal state_longtitutal;
     state_longtitutal[0] = longtitutal_velocity_planner.x(t);

--- a/nav2_frenet_ilqr_controller/src/parameter_handler.cpp
+++ b/nav2_frenet_ilqr_controller/src/parameter_handler.cpp
@@ -67,9 +67,21 @@ ParameterHandler::ParameterHandler(
     node, plugin_name_ + ".frenet_trajectory_planner.step_longtitutal_velocity",
       rclcpp::ParameterValue(
       0.5));
-
+  
+  // for longtitutal velocity
   declare_parameter_if_not_declared(
-    node, plugin_name_ + ".frenet_trajectory_planner.time_interval", rclcpp::ParameterValue(1.0));
+    node, plugin_name_ + ".frenet_trajectory_planner.min_time_interval",
+      rclcpp::ParameterValue(
+      0.7));
+  declare_parameter_if_not_declared(
+    node, plugin_name_ + ".frenet_trajectory_planner.max_time_interval",
+      rclcpp::ParameterValue(
+      1.4));
+  declare_parameter_if_not_declared(
+    node, plugin_name_ + ".frenet_trajectory_planner.step_time_interval",
+      rclcpp::ParameterValue(
+      0.1));
+
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".frenet_trajectory_planner.max_state_in_trajectory",
       rclcpp::ParameterValue(
@@ -130,8 +142,15 @@ ParameterHandler::ParameterHandler(
     params_.frenet_trajectory_planner_config.step_longtitutal_velocity);
 
   node->get_parameter(
-    plugin_name_ + ".frenet_trajectory_planner.time_interval",
-    params_.frenet_trajectory_planner_config.time_interval);
+    plugin_name_ + ".frenet_trajectory_planner.min_time_interval",
+    params_.frenet_trajectory_planner_config.min_time_interval);
+  node->get_parameter(
+    plugin_name_ + ".frenet_trajectory_planner.max_time_interval",
+    params_.frenet_trajectory_planner_config.max_time_interval);
+  node->get_parameter(
+    plugin_name_ + ".frenet_trajectory_planner.step_time_interval",
+    params_.frenet_trajectory_planner_config.step_time_interval);
+
   node->get_parameter(
     plugin_name_ + ".frenet_trajectory_planner.max_state_in_trajectory",
     params_.frenet_trajectory_planner_config.max_state_in_trajectory);
@@ -217,8 +236,12 @@ ParameterHandler::dynamicParametersCallback(
       params_.frenet_trajectory_planner_config.max_longtitutal_velocity = parameter.as_double();
     } else if (name == plugin_name_ + ".frenet_trajectory_planner.step_longtitutal_velocity") {
       params_.frenet_trajectory_planner_config.step_longtitutal_velocity = parameter.as_double();
-    } else if (name == plugin_name_ + ".frenet_trajectory_planner.time_interval") {
-      params_.frenet_trajectory_planner_config.time_interval = parameter.as_double();
+    } else if (name == plugin_name_ + ".frenet_trajectory_planner.min_time_interval") {
+      params_.frenet_trajectory_planner_config.min_time_interval = parameter.as_double();
+    } else if (name == plugin_name_ + ".frenet_trajectory_planner.max_time_interval") {
+      params_.frenet_trajectory_planner_config.max_time_interval = parameter.as_double();
+    } else if (name == plugin_name_ + ".frenet_trajectory_planner.step_time_interval") {
+      params_.frenet_trajectory_planner_config.step_time_interval = parameter.as_double();
     } else if (name == plugin_name_ + ".frenet_trajectory_planner.max_state_in_trajectory") {
       if (parameter.as_int() < 1) {
         params_.frenet_trajectory_planner_config.max_state_in_trajectory = 2;

--- a/nav2_frenet_ilqr_controller/src/parameter_handler.cpp
+++ b/nav2_frenet_ilqr_controller/src/parameter_handler.cpp
@@ -67,7 +67,7 @@ ParameterHandler::ParameterHandler(
     node, plugin_name_ + ".frenet_trajectory_planner.step_longtitutal_velocity",
       rclcpp::ParameterValue(
       0.5));
-  
+
   // for longtitutal velocity
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".frenet_trajectory_planner.min_time_interval",


### PR DESCRIPTION
This is how we cook params
```
FollowPath:
      plugin: "nav2_frenet_ilqr_controller::FrenetILQRController"
      time_discretization: 0.05
      visualize_candidate_trajectories: false
      frenet_trajectory_planner:
        min_lateral_distance: -0.5
        max_lateral_distance: 0.5
        step_lateral_distance: 0.1
        min_longtitutal_velocity: 0.0
        max_longtitutal_velocity: 0.5
        step_longtitutal_velocity: 0.1
        min_time_interval: 0.7
        max_time_interval: 1.4
        step_time_interval: 0.1
        max_state_in_trajectory: 40
      ilqr_trajectory_tracker:
        q_coefficients: [1.0, 1.0, 1.0, 1.0]
        r_coefficients: [0.2, 0.2]
        iteration_number: 20
        alpha: 1.0
        input_limits_min: [-2.5, -1.0]
        input_limits_max: [2.5, 1.0]
      cost_checker_plugins: ["LateralDistanceCostChecker", "LongtitutalVelocityCostChecker", "LatLonBalanceCostChecker"]
      LatLonBalanceCostChecker:
        plugin: "nav2_frenet_ilqr_controller::costs::LatLonBalanceCost"
        K_latlon_balance: 15.0
      LateralDistanceCostChecker:
        plugin: "nav2_frenet_ilqr_controller::costs::LateralDistanceCost"
        K_lateral_distance: 5.0
      LongtitutalVelocityCostChecker:
        plugin: "nav2_frenet_ilqr_controller::costs::LongtitutalVelocityCost"
        K_longtitutal_velocity: 5.0
        desired_velocity: 0.5
        distance_to_approach: 0.8
        desired_velocity_to_approach: 0.1

      policy_plugins: ["ObstaclePolicy"]
      ObstaclePolicy:
        plugin: "nav2_frenet_ilqr_controller::policies::ObstaclePolicy"
```